### PR TITLE
update to 7.6.2

### DIFF
--- a/mingw64-x86_64-libatomic_ops.cygport
+++ b/mingw64-x86_64-libatomic_ops.cygport
@@ -2,7 +2,7 @@ CROSS_HOST="x86_64-w64-mingw32"
 inherit cross
 
 NAME="mingw64-x86_64-libatomic_ops"
-VERSION=7.4.4
+VERSION=7.6.2
 RELEASE=1
 CATEGORY="Devel"
 SUMMARY="Atomic operations library for Win32 toolchain"


### PR DESCRIPTION
Re: https://github.com/andyli/libatomic_ops-cygwin/issues/1

PS. I'm not able to test this one since I got the error msg as follows:

```
$ cygport mingw64-x86_64-libatomic_ops.cygport download
*** ERROR: inherit: unknown cygclass cross
```

I do have the latest version of cygport installed... Do you have any idea?